### PR TITLE
Replace respectively fmat and fvec with mat and vec to repect the pip…

### DIFF
--- a/src/vlGraphics/FlatManipulator.cpp
+++ b/src/vlGraphics/FlatManipulator.cpp
@@ -217,7 +217,7 @@ vl::ref<vl::Geometry> makeScales(bool X, bool Y, bool Z, int numArmTicks, float 
     if(Y)//transfer the Y ruler into the main array
     {
         //rotate the generic ruler around Z axis to create the Y ruler
-        points->transform(vl::fmat4::getRotation(90, 0, 0, 1));
+        points->transform(vl::mat4::getRotation(90, 0, 0, 1));
 
         //copy the Y ruler into the scales array
         for(size_t p=0; p < points->size(); i++, p++)
@@ -228,8 +228,8 @@ vl::ref<vl::Geometry> makeScales(bool X, bool Y, bool Z, int numArmTicks, float 
     if(Z)//transfer the Z ruler into the main array
     {
         //rotate the ruler based on the last rotation
-        vl::fvec3 rotaxis = Y ? vl::fvec3(1,0,0) : vl::fvec3(0,1,0);
-        points->transform(vl::fmat4::getRotation(90,rotaxis));
+        vl::vec3 rotaxis = Y ? vl::vec3(1,0,0) : vl::vec3(0,1,0);
+        points->transform(vl::mat4::getRotation(90,rotaxis));
 
         //copy the Y ruler into the scales array
         for(size_t p=0; p < points->size(); i++, p++)

--- a/src/vlGraphics/ProjViewTransfCallback.cpp
+++ b/src/vlGraphics/ProjViewTransfCallback.cpp
@@ -106,7 +106,7 @@ void ProjViewTransfCallback::updateMatrices(bool cam_changed, bool transf_change
 #if VL_PIPELINE_PRECISION == 1
         glUniformMatrix3fv( glsl_program->vl_NormalMatrix(), 1, GL_FALSE, normalmtx.ptr() ); VL_CHECK_OGL();
 #elif VL_PIPELINE_PRECISION == 2
-        glUniformMatrix3fv( glsl_program->vl_NormalMatrix(), 1, GL_FALSE, ((fmat4)normalmtx).ptr() ); VL_CHECK_OGL();
+        glUniformMatrix3fv( glsl_program->vl_NormalMatrix(), 1, GL_FALSE, ((fmat3)normalmtx).ptr() ); VL_CHECK_OGL();
 #endif
       }
 


### PR DESCRIPTION
…eline precision

In case where Pipeline precision is set to 2, and use double instead of float, compilation stopped with error.
The linked issue is https://github.com/MicBosi/VisualizationLibrary/issues/147


I simply change fmat _n_ / fvec _n_ with mat _n_ / vec _n_ 