### PR TITLE
Conflict with ESilhouetteMode when both files are used

### DIFF
--- a/src/vlGraphics/Extrusion.hpp
+++ b/src/vlGraphics/Extrusion.hpp
@@ -37,10 +37,11 @@
 #include <vlCore/Vector3.hpp>
 #include <vlCore/Matrix4.hpp>
 #include <vector>
+#include <vlGraphics/ExtrusionPrimitives.hpp>
 
 namespace vl
 {
-  typedef enum { SilhouetteClosed, SilhouetteOpen } ESilhouetteMode;
+
   /**
    * The Extrusion class generates a Geometry extruding a silhouette along a path.
    * \sa

--- a/src/vlGraphics/ExtrusionPrimitives.hpp
+++ b/src/vlGraphics/ExtrusionPrimitives.hpp
@@ -1,0 +1,42 @@
+/**************************************************************************************/
+/*                                                                                    */
+/*  Visualization Library                                                             */
+/*  http://visualizationlibrary.org                                                   */
+/*                                                                                    */
+/*  Copyright (c) 2005-2020, Michele Bosi                                             */
+/*  All rights reserved.                                                              */
+/*                                                                                    */
+/*  Redistribution and use in source and binary forms, with or without modification,  */
+/*  are permitted provided that the following conditions are met:                     */
+/*                                                                                    */
+/*  - Redistributions of source code must retain the above copyright notice, this     */
+/*  list of conditions and the following disclaimer.                                  */
+/*                                                                                    */
+/*  - Redistributions in binary form must reproduce the above copyright notice, this  */
+/*  list of conditions and the following disclaimer in the documentation and/or       */
+/*  other materials provided with the distribution.                                   */
+/*                                                                                    */
+/*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND   */
+/*  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED     */
+/*  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE            */
+/*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR  */
+/*  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES    */
+/*  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;      */
+/*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON    */
+/*  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT           */
+/*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS     */
+/*  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                      */
+/*                                                                                    */
+/**************************************************************************************/
+
+#ifndef ExtrusionPrimitives_INCLUDE_ONCE
+#define ExtrusionPrimitives_INCLUDE_ONCE
+
+
+
+namespace vl
+{
+  typedef enum { SilhouetteClosed, SilhouetteOpen } ESilhouetteMode;
+}
+
+#endif

--- a/src/vlGraphics/Extrusions.hpp
+++ b/src/vlGraphics/Extrusions.hpp
@@ -37,10 +37,11 @@
 #include <vlCore/Vector3.hpp>
 #include <vlCore/Matrix4.hpp>
 #include <vector>
+#include <vlGraphics/ExtrusionPrimitives.hpp>
 
 namespace vl
 {
-  typedef enum { SilhouetteClosed, SilhouetteOpen } ESilhouetteMode;
+
   /**
    * The Extrusion class generates a Geometry extruding a silhouette along a path.
    * \sa


### PR DESCRIPTION
Hello,
I found this problem when i tried to upgrade my VL version to 2.0

ESilhouetteMode Enum is declared both in Extrusion.hpp and Extrusions.hpp