### PR TITLE
vlVG fix

### DIFF
--- a/src/vlVG/SceneManagerVectorGraphics.hpp
+++ b/src/vlVG/SceneManagerVectorGraphics.hpp
@@ -35,10 +35,10 @@
 #include <vlGraphics/SceneManager.hpp>
 #include <vlCore/Collection.hpp>
 #include <vlGraphics/Frustum.hpp>
+#include <vlVG/VectorGraphics.hpp>
 
 namespace vl
 {
-  class VectorGraphics;
 //-------------------------------------------------------------------------------------------------------------------------------------------
 // SceneManagerVectorGraphics
 //-------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
SceneManagerVectorGraphics.hpp file is invalid without VectorGraphics.hpp

example usage:
//#include <vlVG/VectorGraphics.hpp> // without it don't work - compile error
#include <vlVG/SceneManagerVectorGraphics.hpp>

CE, 86 line:
"vectorGraphicObjects()->at(i)->actors()" (VectorGraphics is undefined)