### PR TITLE
fix build error under msys2 with wxWidgets option enabled

### DIFF
--- a/src/gui/vlWX/WXGLCanvas.hpp
+++ b/src/gui/vlWX/WXGLCanvas.hpp
@@ -32,15 +32,16 @@
 #ifndef vlWXGLCanvas_INCLUDE_ONCE
 #define vlWXGLCanvas_INCLUDE_ONCE
 
-#include <vlWX/link_config.hpp>
-#include <vlGraphics/OpenGLContext.hpp>
-#include <vlCore/Time.hpp>
 #include <wx/frame.h>
 #include <wx/glcanvas.h>
 #include <wx/timer.h>
 #include <wx/dcclient.h>
 #include <wx/image.h>
 #include <wx/app.h>
+#include <vlWX/link_config.hpp>
+#include <vlGraphics/OpenGLContext.hpp>
+#include <vlCore/Time.hpp>
+
 
 #if !wxUSE_GLCANVAS
   #error "OpenGL required: set wxUSE_GLCANVAS to 1 and rebuild the library"


### PR DESCRIPTION
see discussion here:
when building this library wxWidgets support under msys2, I got build error, here is a patch to fix the error Issue #210 · MicBosi/VisualizationLibrary — https://github.com/MicBosi/VisualizationLibrary/issues/210