### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/external/zlib/crc32.c
+++ b/src/external/zlib/crc32.c
@@ -278,7 +278,7 @@ local unsigned long crc32_little(crc, buf, len)
 }
 
 /* ========================================================================= */
-#define DOBIG4 c ^= *++buf4; \
+#define DOBIG4 c ^= *buf4++; \
         c = crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
             crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24]
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
@@ -300,7 +300,6 @@ local unsigned long crc32_big(crc, buf, len)
     }
 
     buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
-    buf4--;
     while (len >= 32) {
         DOBIG32;
         len -= 32;
@@ -309,7 +308,6 @@ local unsigned long crc32_big(crc, buf, len)
         DOBIG4;
         len -= 4;
     }
-    buf4++;
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in src/external/zlib/crc32.c which was cloned from madler/zlib but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2016-9843.

### Proposed Fix
Apply the same patch as the one in madler/zlib to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2016-9843
https://github.com/madler/zlib/commit/d1d577490c15a0c6862473d7576352a9f18ef811