### PR TITLE
Fix Security: Avoid pre-decrement of pointer in cloned code

### DIFF
--- a/src/external/zlib/crc32.c
+++ b/src/external/zlib/crc32.c
@@ -278,7 +278,7 @@ local unsigned long crc32_little(crc, buf, len)
 }
 
 /* ========================================================================= */
-#define DOBIG4 c ^= *++buf4; \
+#define DOBIG4 c ^= *buf4++; \
         c = crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
             crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24]
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
@@ -300,7 +300,6 @@ local unsigned long crc32_big(crc, buf, len)
     }
 
     buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
-    buf4--;
     while (len >= 32) {
         DOBIG32;
         len -= 32;
@@ -309,7 +308,6 @@ local unsigned long crc32_big(crc, buf, len)
         DOBIG4;
         len -= 4;
     }
-    buf4++;
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {


### PR DESCRIPTION
This PR fixes a potential security vulnerability in crc32_big() that was cloned from https://github.com/madler/zlib but did not receive the security patch.

### Details:
Affected Function: crc32_big() in src/external/zlib/crc32.c
Original Fix: https://github.com/madler/zlib/commit/d1d577490c15a0c6862473d7576352a9f18ef811

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/madler/zlib/commit/d1d577490c15a0c6862473d7576352a9f18ef811
- https://nvd.nist.gov/vuln/detail/cve-2016-9843

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
