### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/external/freetype/src/pcf/pcfread.c
+++ b/src/external/freetype/src/pcf/pcfread.c
@@ -812,6 +812,15 @@ THE SOFTWARE.
     if ( !PCF_FORMAT_MATCH( format, PCF_DEFAULT_FORMAT ) )
       return FT_THROW( Invalid_File_Format );
 
+    /* sanity checks */
+    if ( firstCol < 0       ||
+         firstCol > lastCol ||
+         lastCol  > 0xFF    ||
+         firstRow < 0       ||
+         firstRow > lastRow ||
+         lastRow  > 0xFF    )
+      return FT_THROW( Invalid_Table );
+
     FT_TRACE4(( "pdf_get_encodings:\n" ));
 
     FT_TRACE4(( "  firstCol %d, lastCol %d, firstRow %d, lastRow %d\n",


### PR DESCRIPTION
This PR fixes a potential security vulnerability in pcf_get_encodings that was cloned from https://cgit.git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=ef1eba75187adfac750f326b563fe543dd5ff4e6 but did not receive the security patch.

### Details:
Affected Function: pcf_get_encodings in src/external/freetype/src/pcf/pcfread.c
Original Fix: https://cgit.git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=ef1eba75187adfac750f326b563fe543dd5ff4e6

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://cgit.git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=ef1eba75187adfac750f326b563fe543dd5ff4e6
- https://nvd.nist.gov/vuln/detail/CVE-2014-9670

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
